### PR TITLE
Make plugin Moodle 3.7-3.5 compatible #21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,14 @@ dist: trusty
 
 matrix:
   include:
+    - php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE CORE_PATCH=core35.patch
+    - php: 7.1
+      env: DB=pgsql  MOODLE_BRANCH=MOODLE_35_STABLE CORE_PATCH=core35.patch
+    - php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_36_STABLE CORE_PATCH=core36.patch
+    - php: 7.1
+      env: DB=pgsql  MOODLE_BRANCH=MOODLE_36_STABLE CORE_PATCH=core36.patch
     - php: 7.2
       env: DB=mysqli MOODLE_BRANCH=MOODLE_37_STABLE
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,6 @@ dist: trusty
 
 matrix:
   include:
-    - php: 7.1
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
-    - php: 7.1
-      env: DB=pgsql  MOODLE_BRANCH=MOODLE_35_STABLE
-    - php: 7.1
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_36_STABLE
-    - php: 7.1
-      env: DB=pgsql  MOODLE_BRANCH=MOODLE_36_STABLE
     - php: 7.2
       env: DB=mysqli MOODLE_BRANCH=MOODLE_37_STABLE
     - php: 7.2

--- a/README.md
+++ b/README.md
@@ -47,6 +47,43 @@ That other major difference is that we support multiple authentication factor *t
 
 ## Installation
 
+Step 1: Install the local module
+--------------------------------
+
+Using git submodule:
+
+```
+git submodule add git@github.com:catalyst/moodle-tool_mfa.git admin/tool/mfa
+```
+
+OR you can download as a zip from github
+
+https://github.com/catalyst/moodle-tool_mfa/archive/master.zip
+
+Extract this into /var/www/yourmoodle/admin/tool/mfa/
+
+Then run the moodle upgrade as normal.
+
+
+Step 2: Apply core patches
+-------------------------------
+
+This plugin uses MDL-60470 improvement which was only added 3.7.
+
+You can apply it in one line for 3.5 and 3.6:
+
+For Moodle 3.5:
+
+```
+git apply admin/tool/mfa/core35.patch
+```
+
+For Moodle 3.6:
+
+```
+git apply admin/tool/mfa/core36.patch
+```
+
 ## Configuration
 
 

--- a/core35.patch
+++ b/core35.patch
@@ -1,0 +1,51 @@
+From a2fce8934932249bc0499e5b365ba0b8fc80a910 Mon Sep 17 00:00:00 2001
+From: Mikhail Golenkov <mikhailgolenkov@catalyst-au.net>
+Date: Wed, 13 Nov 2019 11:19:58 +1100
+Subject: [PATCH] MDL-60470 core: New hook 'after_require_login'
+
+---
+ lib/moodlelib.php | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/lib/moodlelib.php b/lib/moodlelib.php
+index 3ac3d8be1b7..a7b6b8b0215 100644
+--- a/lib/moodlelib.php
++++ b/lib/moodlelib.php
+@@ -2705,6 +2705,8 @@ function require_login($courseorid = null, $autologinguest = true, $cm = null, $
+         $CFG->forceclean = true;
+     }
+ 
++    $afterlogins = get_plugins_with_function('after_require_login', 'lib.php');
++
+     // Do not bother admins with any formalities, except for activities pending deletion.
+     if (is_siteadmin() && !($cm && $cm->deletioninprogress)) {
+         // Set the global $COURSE.
+@@ -2716,6 +2718,12 @@ function require_login($courseorid = null, $autologinguest = true, $cm = null, $
+         }
+         // Set accesstime or the user will appear offline which messes up messaging.
+         user_accesstime_log($course->id);
++
++        foreach ($afterlogins as $plugintype => $plugins) {
++            foreach ($plugins as $pluginfunction) {
++                $pluginfunction($courseorid, $autologinguest, $cm, $setwantsurltome, $preventredirect);
++            }
++        }
+         return;
+     }
+ 
+@@ -2923,6 +2931,12 @@ function require_login($courseorid = null, $autologinguest = true, $cm = null, $
+         $PAGE->set_course($course);
+     }
+ 
++    foreach ($afterlogins as $plugintype => $plugins) {
++        foreach ($plugins as $pluginfunction) {
++            $pluginfunction($courseorid, $autologinguest, $cm, $setwantsurltome, $preventredirect);
++        }
++    }
++
+     // Finally access granted, update lastaccess times.
+     user_accesstime_log($course->id);
+ }
+-- 
+2.17.1
+

--- a/core36.patch
+++ b/core36.patch
@@ -1,0 +1,53 @@
+From bf9f255523e5f8feb7cb39067475389ba260ff4e Mon Sep 17 00:00:00 2001
+From: Brendan Heywood <brendan@catalyst-au.net>
+Date: Wed, 18 Oct 2017 16:20:33 +1100
+Subject: [PATCH] MDL-60470 core: New hook 'after_require_login'
+
+This adds a hook towards the end of the require_login function.
+---
+ lib/moodlelib.php | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/lib/moodlelib.php b/lib/moodlelib.php
+index 1cc6caa2b37..f3b227f6b4c 100644
+--- a/lib/moodlelib.php
++++ b/lib/moodlelib.php
+@@ -2764,6 +2764,8 @@ function require_login($courseorid = null, $autologinguest = true, $cm = null, $
+         $CFG->forceclean = true;
+     }
+ 
++    $afterlogins = get_plugins_with_function('after_require_login', 'lib.php');
++
+     // Do not bother admins with any formalities, except for activities pending deletion.
+     if (is_siteadmin() && !($cm && $cm->deletioninprogress)) {
+         // Set the global $COURSE.
+@@ -2778,6 +2780,12 @@ function require_login($courseorid = null, $autologinguest = true, $cm = null, $
+         if (!WS_SERVER && !AJAX_SCRIPT) {
+             user_accesstime_log($course->id);
+         }
++
++        foreach ($afterlogins as $plugintype => $plugins) {
++            foreach ($plugins as $pluginfunction) {
++                $pluginfunction($courseorid, $autologinguest, $cm, $setwantsurltome, $preventredirect);
++            }
++        }
+         return;
+     }
+ 
+@@ -2995,6 +3003,12 @@ function require_login($courseorid = null, $autologinguest = true, $cm = null, $
+         $PAGE->set_course($course);
+     }
+ 
++    foreach ($afterlogins as $plugintype => $plugins) {
++        foreach ($plugins as $pluginfunction) {
++            $pluginfunction($courseorid, $autologinguest, $cm, $setwantsurltome, $preventredirect);
++        }
++    }
++
+     // Finally access granted, update lastaccess times.
+     // Do not update access time for webservice or ajax requests.
+     if (!WS_SERVER && !AJAX_SCRIPT) {
+
+-- 
+2.17.1
+

--- a/db/subplugins.php
+++ b/db/subplugins.php
@@ -15,10 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Plugin version and other meta-data are defined here.
+ * Definition of MFA sub-plugins (factors).
  *
- * @package     factor_range
- * @subpackage  tool_mfa
+ * @package     tool_mfa
  * @author      Mikhail Golenkov <golenkovm@gmail.com>
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
@@ -26,9 +25,4 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version      = 2019102400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2019041800.00;   // Requires MDL-60470 improvement.
-$plugin->component    = 'factor_iprange';
-$plugin->release      = 'v0.1';
-$plugin->maturity     = MATURITY_STABLE;
-$plugin->dependencies = array('tool_mfa' => 2019102400);
+$subplugins = (array) json_decode(file_get_contents($CFG->dirroot."/admin/tool/mfa/db/subplugins.json"))->plugintypes;

--- a/factor/auth/version.php
+++ b/factor/auth/version.php
@@ -27,7 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version      = 2019102400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2019041800.00;   // Requires MDL-60470 improvement.
+$plugin->requires     = 2018051708.05;   // Requires MDL-60470 improvement.
 $plugin->component    = 'factor_auth';
 $plugin->release      = 'v0.1';
 $plugin->maturity     = MATURITY_STABLE;

--- a/factor/auth/version.php
+++ b/factor/auth/version.php
@@ -27,7 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version      = 2019102400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2019101800;      // Requires MDL-66173 improvement.
+$plugin->requires     = 2019041800.00;   // Requires MDL-60470 improvement.
 $plugin->component    = 'factor_auth';
 $plugin->release      = 'v0.1';
 $plugin->maturity     = MATURITY_STABLE;

--- a/factor/email/version.php
+++ b/factor/email/version.php
@@ -27,7 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version      = 2019102400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2019041800.00;   // Requires MDL-60470 improvement.
+$plugin->requires     = 2018051708.05;   // Requires MDL-60470 improvement.
 $plugin->component    = 'factor_email';
 $plugin->release      = 'v0.1';
 $plugin->maturity     = MATURITY_STABLE;

--- a/factor/email/version.php
+++ b/factor/email/version.php
@@ -27,7 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version      = 2019102400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2019101800;      // Requires MDL-66173 improvement.
+$plugin->requires     = 2019041800.00;   // Requires MDL-60470 improvement.
 $plugin->component    = 'factor_email';
 $plugin->release      = 'v0.1';
 $plugin->maturity     = MATURITY_STABLE;

--- a/factor/iprange/version.php
+++ b/factor/iprange/version.php
@@ -27,7 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version      = 2019102400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2019041800.00;   // Requires MDL-60470 improvement.
+$plugin->requires     = 2018051708.05;   // Requires MDL-60470 improvement.
 $plugin->component    = 'factor_iprange';
 $plugin->release      = 'v0.1';
 $plugin->maturity     = MATURITY_STABLE;

--- a/factor/totp/version.php
+++ b/factor/totp/version.php
@@ -27,7 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version      = 2019110400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2019101800;      // Requires MDL-66173 improvement.
+$plugin->requires     = 2019041800.00;   // Requires MDL-60470 improvement.
 $plugin->component    = 'factor_totp';
 $plugin->release      = 'v0.1';
 $plugin->maturity     = MATURITY_STABLE;

--- a/factor/totp/version.php
+++ b/factor/totp/version.php
@@ -27,7 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version      = 2019110400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2019041800.00;   // Requires MDL-60470 improvement.
+$plugin->requires     = 2018051708.05;   // Requires MDL-60470 improvement.
 $plugin->component    = 'factor_totp';
 $plugin->release      = 'v0.1';
 $plugin->maturity     = MATURITY_STABLE;

--- a/index.php
+++ b/index.php
@@ -28,7 +28,8 @@ require_once(__DIR__ . '/lib.php');
 require_once($CFG->libdir.'/adminlib.php');
 require_once($CFG->libdir.'/tablelib.php');
 
-require_admin();
+require_login(null, false);
+require_capability('moodle/site:config', context_system::instance());
 
 global $_SERVER;
 $returnurl = $_SERVER['HTTP_REFERER'];

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2019102400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires  = 2019041800.00;   // Requires MDL-60470 improvement.
+$plugin->requires  = 2018051708.05;   // Requires MDL-60470 improvement.
 $plugin->component = 'tool_mfa';
 $plugin->release   = 'v0.1';
 $plugin->maturity  = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2019102400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires  = 2019101800;      // Requires MDL-66173 improvement.
+$plugin->requires  = 2019041800.00;   // Requires MDL-60470 improvement.
 $plugin->component = 'tool_mfa';
 $plugin->release   = 'v0.1';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Issue #21 
- Updated `$plugin->requires` in version files for main plugin and factor: requires MDL-60470 improvement;
- Replace `require_admin()` by older implementation;
- Remove unnessesary Moodle versions from Travis configuration;
- Add old subplugins.php for Moodle 3.7.