### PR TITLE
Issue 58: Added passing for no input factors

### DIFF
--- a/classes/plugininfo/factor.php
+++ b/classes/plugininfo/factor.php
@@ -142,21 +142,15 @@ class factor extends \core\plugininfo\base {
      * @return mixed factor object the next factor to be authenticated or false.
      */
     public static function get_next_user_factor() {
-        global $SESSION;
-        $factors = self::get_enabled_factors();
+        $factors = self::get_active_user_factor_types();
 
         foreach ($factors as $factor) {
-            // If factor doesn't have input, move on.
             if (!$factor->has_input()) {
                 continue;
             }
 
-            $userfactors = $factor->get_active_user_factors();
-            foreach ($userfactors as $userfactor) {
-                $property = 'factor_'.$userfactor->name;
-                if (empty($SESSION->$property) || self::STATE_FAIL == $SESSION->$property) {
-                    return $userfactor;
-                }
+            if ($factor->get_state() == self::STATE_UNKNOWN || $factor->get_state() == self::STATE_FAIL) {
+                return $factor;
             }
         }
 

--- a/classes/plugininfo/factor.php
+++ b/classes/plugininfo/factor.php
@@ -146,6 +146,11 @@ class factor extends \core\plugininfo\base {
         $factors = self::get_enabled_factors();
 
         foreach ($factors as $factor) {
+            // If factor doesn't have input, move on.
+            if (!$factor->has_input()) {
+                continue;
+            }
+
             $userfactors = $factor->get_active_user_factors();
             foreach ($userfactors as $userfactor) {
                 $property = 'factor_'.$userfactor->name;

--- a/tests/plugininfo_factor_test.php
+++ b/tests/plugininfo_factor_test.php
@@ -1,0 +1,66 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Plugin version and other meta-data are defined here.
+ *
+ * @package     tool_mfa
+ * @author      Peter Burnett <peterburnett@catalyst-au.net>
+ * @copyright   Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+class tool_mfa_plugininfo_factor_testcase extends advanced_testcase {
+    public function test_get_next_user_factor() {
+        $this->resetAfterTest(true);
+        // Create and login a user.
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+        // Test that with no enabled factors, false is returned.
+        $this->assertFalse(\tool_mfa\plugininfo\factor::get_next_user_factor());
+
+        // Setup enabled totp factor for user.
+        set_config('enabled', 1, 'factor_totp');
+        $totpfactor = \tool_mfa\plugininfo\factor::get_factor('totp');
+        $totpdata = [
+            'secret' => 'fakekey',
+            'devicename' => 'fakedevice'
+        ];
+        $this->assertTrue($totpfactor->setup_user_factor((object) $totpdata));
+
+        // Test that factor now appears (from STATE_UNKNOWN).
+        $this->assertEquals(\tool_mfa\plugininfo\factor::get_next_user_factor()->name, 'totp');
+
+        // Now pass this factor
+        $totpfactor->set_state(\tool_mfa\plugininfo\factor::STATE_PASS);
+        $this->assertFalse(\tool_mfa\plugininfo\factor::get_next_user_factor());
+
+        // Add in a no-input factor
+        set_config('enabled', 1, 'factor_auth');
+        $this->assertEquals(2, count(\tool_mfa\plugininfo\factor::get_enabled_factors()));
+
+        $authfactor = \tool_mfa\plugininfo\factor::get_factor('auth');
+        $this->assertTrue($authfactor->is_enabled());
+        $this->assertFalse($authfactor->has_setup());
+
+        // TODO: Enable when a no_input factor is ready
+        /*$this->assertEquals(2, count(\tool_mfa\plugininfo\factor::get_active_user_factor_types()));
+        $this->assertFalse(\tool_mfa\plugininfo\factor::get_next_user_factor());*/
+    }
+}
+


### PR DESCRIPTION
Closes #58. Checks for whether a factor requires state before adding it to the queue of factors to work through. tool_mfa_user_passed_enough_factors() checks get_state which performs the factor check then.