### PR TITLE
Fixed Renderer issue with not_enough_factors

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -37,8 +37,6 @@ $PAGE->set_pagelayout('secure');
 $pagetitle = $SITE->shortname.': '.get_string('mfa', 'tool_mfa');
 $PAGE->set_title($pagetitle);
 
-$OUTPUT = $PAGE->get_renderer('tool_mfa');
-
 $currenturl = new moodle_url('/admin/tool/mfa/auth.php');
 
 // Perform state check.

--- a/classes/manager.php
+++ b/classes/manager.php
@@ -171,10 +171,21 @@ class manager {
      * @return void
      */
     public static function cannot_login() {
-        global $OUTPUT, $USER;
-        echo $OUTPUT->header();
-        echo $OUTPUT->not_enough_factors();
-        echo $OUTPUT->footer();
+        global $ME, $PAGE, $USER;
+
+        // Determine page URL without triggering warnings from $PAGE.
+        if (!preg_match("~(\/admin\/tool\/mfa\/auth.php)~", $ME)) {
+            // If URL isn't set, we need to redir to auth.php.
+            // This ensures URL and required info is correctly set.
+            // Then we arrive back here.
+            redirect(new \moodle_url('/admin/tool/mfa/auth.php'));
+        }
+
+        $renderer = $PAGE->get_renderer('tool_mfa');
+
+        echo $renderer->header();
+        echo $renderer->not_enough_factors();
+        echo $renderer->footer();
         // Emit an event for failure, then logout.
         $event = \tool_mfa\event\user_failed_mfa::user_failed_mfa_event($USER);
         $event->trigger();


### PR DESCRIPTION
This fixed a bug where a core renderer would get called instead of the MFA renderer, if the auth.php page hadn't been reached