### PR TITLE
Issue #204: Optimised hooks

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -38,7 +38,9 @@ function tool_mfa_after_require_login($courseorid = null, $autologinguest = null
         $SESSION->mfa_login_hook_test = true;
     }
 
-    \tool_mfa\manager::require_auth($courseorid, $autologinguest, $cm, $setwantsurltome, $preventredirect);
+    if (empty($SESSION->tool_mfa_authenticated)) {
+        \tool_mfa\manager::require_auth($courseorid, $autologinguest, $cm, $setwantsurltome, $preventredirect);
+    }
 }
 
 /**


### PR DESCRIPTION
Closes #204 
There was already caching present for most of the MFA operations, however manager::is_ready was being called on every page. The actual call to require_auth in after_require_login can be put behind the same SESSION check that is present in after_config. This change resulted in execution time for a plain page load after an MFA auth to go from 9243 microseconds to 4 microseconds