### PR TITLE
Totara Compatability fix

### DIFF
--- a/classes/manager.php
+++ b/classes/manager.php
@@ -423,10 +423,13 @@ class manager {
 
         // Site policy.
         if (isset($USER->policyagreed) && !$USER->policyagreed) {
-            $manager = new \core_privacy\local\sitepolicy\manager();
-            $policyurl = $manager->get_redirect_url(false);
-            if (!empty($policyurl) && $url->compare($policyurl, URL_MATCH_BASE)) {
-                return self::NO_REDIRECT;
+            // Privacy classes may not exist in older Moodles/Totara
+            if (class_exists('\core_privacy\local\sitepolicy\manager')) {
+                $manager = new \core_privacy\local\sitepolicy\manager();
+                $policyurl = $manager->get_redirect_url(false);
+                if (!empty($policyurl) && $url->compare($policyurl, URL_MATCH_BASE)) {
+                    return self::NO_REDIRECT;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes a bug where totara would crash on login due to the \core_privacy\local\sitepolicy\manager class not existing