### PR TITLE
Issue #181: Fix TOTP factor setup for wwwroots and site names containing colons

### DIFF
--- a/factor/totp/classes/factor.php
+++ b/factor/totp/classes/factor.php
@@ -55,16 +55,17 @@ class factor extends object_factor_base {
 
     /**
      * Generates TOTP URI for given secret key.
-     * Uses site name, domain and user name to make GA account look like:
-     * "Sitename domain (username)"
+     * Uses site name, hostname and user name to make GA account look like:
+     * "Sitename hostname (username)".
      *
      * @param string $secret
      * @return string
      */
     public function generate_totp_uri($secret) {
         global $USER, $SITE, $CFG;
-        $domain = str_replace('http://', '', str_replace('https://', '', $CFG->wwwroot));
-        $issuer = $SITE->fullname.' '.$domain;
+        $host = parse_url($CFG->wwwroot, PHP_URL_HOST);
+        $sitename = str_replace(':', '', $SITE->fullname);
+        $issuer = $sitename.' '.$host;
         $totp = TOTP::create($secret);
         $totp->setLabel($USER->username);
         $totp->setIssuer($issuer);


### PR DESCRIPTION
The parameter to TOTP::setIssuer() must not contain a colon; it's
unsupported by the library. The issuer string includes the site name and
the wwwroot's hostname/domain, so we need to ensure that neither
component can sneak a colon in.

  * In order to include the desired domain in the issuer string, use
    parse_url() to extract the PHP_URL_HOST surgically, without the
    problem of accidentally including port numbers and/or usernames and
    passwords, all of which could be part of the URL.  Standards are in
    agreement that bare host names must not include colons.

    It should be noted then that the "domain" can actually be just an IP
    address, e.g. in the case of "https://127.0.0.1". Rename to hostname.

  * There is no good way to replace colons in human-readable site names
    without maiming the original string in some way.

    We just remove the colon.

    Only the semicolon or the dot is likely to be used with similar
    spacing of preceding and following words (in the English language
    anyway), and replacing the colon with either one would make the
    resulting string even more awkward to read than just removing it.

    According to [1], a colon is the only forbidden character, so we
    should be fine by going this route.

----
[1] https://github.com/Spomky-Labs/otphp/blob/6f1cd6e11a64f8fcd2c8ceb17442f456d310f820/src/ParameterTrait.php#L177