### PR TITLE
Fix target url of 'not enough factors' page

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -224,7 +224,7 @@ class tool_mfa_renderer extends plugin_renderer_base {
         $return = $this->output->notification($notification, 'notifyerror');
 
         // Logout button.
-        $url = new \moodle_url('\admin\tool\mfa\auth.php', ['logout' => 1]);
+        $url = new \moodle_url('/admin/tool/mfa/auth.php', ['logout' => 1]);
         $btn = new \single_button($url, get_string('logout'), 'post', true);
         $return .= $this->render($btn);
 


### PR DESCRIPTION
I am starting work on rebasing #230 / #231 PRs on the new codebase. 

As a first step, I factored out  a change to `renderer.php` as it does not logically relate to the two new factors. Without the change, it is impossible to log out and re-try login if not enough factors could be supplied. In particular, this is a problem when testing a new factor implementation ;) 

IIRC this change was originally done by @Laur0r, so I attributed the commit to her.