### PR TITLE
Set default value of safeips setting to an empty string

### DIFF
--- a/factor/iprange/settings.php
+++ b/factor/iprange/settings.php
@@ -53,5 +53,5 @@ $info = $OUTPUT->notification(get_string($message, 'factor_iprange', ['ip' => ge
 $settings->add(new admin_setting_configiplist('factor_iprange/safeips',
     new lang_string('settings:safeips', 'factor_iprange'),
     new lang_string('settings:safeips_help', 'factor_iprange',
-            array('info' => $info, 'syntax' => get_string('ipblockersyntax', 'admin'))), null, PARAM_TEXT));
+            array('info' => $info, 'syntax' => get_string('ipblockersyntax', 'admin'))), '', PARAM_TEXT));
 


### PR DESCRIPTION
This is a fix for #254 
