### PR TITLE
Removed additional call to config.php

### DIFF
--- a/tests/manager_test.php
+++ b/tests/manager_test.php
@@ -346,7 +346,6 @@ class tool_mfa_manager_testcase extends tool_mfa_testcase {
 
     public function test_core_hooks() {
         // Setup test and user.
-        require_once(__DIR__ . '/../../../../config.php');
         global $CFG, $SESSION;
         $this->resetAfterTest(true);
         $user = $this->getDataGenerator()->create_user();


### PR DESCRIPTION
Removed additional call to config.php from testcase `test_core_hooks()`. This caused failing unit test in Totara 13

```
There was 1 error:

1) tool_mfa\tests\tool_mfa_manager_testcase::test_core_hooks
Unexpected debugging() call detected.
Debugging: Please remove additional calls to include config.php in your scripts
* line 104 of /lib/init.php: call to debugging()
* line 41 of /config.php: call to core\internal\config::initialise()
* line 348 of /admin/tool/mfa/tests/manager_test.php: call to require_once()
* line 1415 of /var/www/test/phpunit/vendor/phpunit/phpunit/src/Framework/TestCase.php: call to tool_mfa\tests\tool_mfa_manager_testcase->test_core_hooks()
* line 1035 of /var/www/test/phpunit/vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 665 of /lib/phpunit/classes/base_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 68 of /lib/phpunit/classes/advanced_testcase.php: call to base_testcase->runBare()
* line 691 of /var/www/test/phpunit/vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 763 of /var/www/test/phpunit/vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 601 of /var/www/test/phpunit/vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 633 of /var/www/test/phpunit/vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 204 of /var/www/test/phpunit/vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->doRun()
* line 163 of /var/www/test/phpunit/vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 61 of /var/www/test/phpunit/vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()


/var/www/server/lib/phpunit/classes/advanced_testcase.php:76

To re-run:
 test/phpunit/vendor/phpunit/phpunit/phpunit -c /var/www/test/phpunit/phpunit.xml server/admin/tool/mfa/tests/manager_test.php
```