### PR TITLE
Fix validation logic error

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -65,24 +65,24 @@ if ($form->is_submitted()) {
         // Increment the fail counter for the factor,
         // And let the factor handle locking logic.
         $factor->increment_lock_counter();
-        \tool_mfa\manager::resolve_mfa_status(true);
-    }
-
-    // Set state from user actions.
-    if ($form->is_cancelled()) {
-        $factor->process_cancel_action();
-        // Move to next factor.
-        \tool_mfa\manager::resolve_mfa_status(true);
+        \tool_mfa\manager::resolve_mfa_status(false);
     } else {
-        if ($data = $form->get_data()) {
-            // Did user submit something that causes a fail state?
-            if ($factor->get_state() == \tool_mfa\plugininfo\factor::STATE_FAIL) {
-                \tool_mfa\manager::resolve_mfa_status(true);
-            }
-
-            $factor->set_state(\tool_mfa\plugininfo\factor::STATE_PASS);
+        // Set state from user actions.
+        if ($form->is_cancelled()) {
+            $factor->process_cancel_action();
             // Move to next factor.
             \tool_mfa\manager::resolve_mfa_status(true);
+        } else {
+            if ($data = $form->get_data()) {
+                // Did user submit something that causes a fail state?
+                if ($factor->get_state() == \tool_mfa\plugininfo\factor::STATE_FAIL) {
+                    \tool_mfa\manager::resolve_mfa_status(true);
+                }
+
+                $factor->set_state(\tool_mfa\plugininfo\factor::STATE_PASS);
+                // Move to next factor.
+                \tool_mfa\manager::resolve_mfa_status(true);
+            }
         }
     }
 }


### PR DESCRIPTION
Instead of allowing the mfa status check to handle the page redirection to start a new attempt,
fall out of the status checks after the validation fail, to properly display validation messages.