### PR TITLE
Use set_allow_xss to mark elements as safe for newer Totara versions

### DIFF
--- a/classes/local/form/setup_factor_form.php
+++ b/classes/local/form/setup_factor_form.php
@@ -38,6 +38,7 @@ class setup_factor_form extends \moodleform {
         $factorname = $this->_customdata['factorname'];
         $factor = \tool_mfa\plugininfo\factor::get_factor($factorname);
         $mform = $factor->setup_factor_form_definition($mform);
+        $this->xss_whitelist_static_form_elements($mform);
 
     }
 
@@ -68,6 +69,28 @@ class setup_factor_form extends \moodleform {
         $factorname = $this->_customdata['factorname'];
         $factor = \tool_mfa\plugininfo\factor::get_factor($factorname);
         $mform = $factor->setup_factor_form_definition_after_data($mform);
+        $this->xss_whitelist_static_form_elements($mform);
         $this->add_action_buttons();
+    }
+
+
+    /**
+     * In newer versions of Totara with consistent cleaning enabled we need to ensure to mark static elements
+     *  as "xss safe". Or in Totara's ideal world to use 'html' if form-like display is not required.
+     *
+     * @param \HTML_QuickForm $mform
+     * @return void
+     */
+    private function xss_whitelist_static_form_elements($mform) {
+        if (!method_exists('MoodleQuickForm_static', 'set_allow_xss')) {
+            return;
+        }
+
+        $elements = $mform->_elements;
+        foreach ($elements as $element) {
+            if (is_a($element, 'MoodleQuickForm_static')) {
+                $element->set_allow_xss(true);
+            }
+        }
     }
 }

--- a/patch/TOTARA_16.patch
+++ b/patch/TOTARA_16.patch
@@ -1,0 +1,61 @@
+diff --git a/server/lib/moodlelib.php b/server/lib/moodlelib.php
+index e80b84cb652..033de11df7f 100644
+--- a/server/lib/moodlelib.php
++++ b/server/lib/moodlelib.php
+@@ -2895,6 +2895,8 @@ function require_login($courseorid = null, $autologinguest = true, $cm = null, $
+     // Make sure the USER has a sesskey set up. Used for CSRF protection.
+     sesskey();
+ 
++    $afterlogins = get_plugins_with_function('after_require_login', 'lib.php');
++
+     // Do not bother admins with any formalities, except for activities pending deletion.
+     if (is_siteadmin() && !($cm && $cm->deletioninprogress)) {
+         // Set the global $COURSE.
+@@ -2906,6 +2908,12 @@ function require_login($courseorid = null, $autologinguest = true, $cm = null, $
+         }
+         // Set accesstime or the user will appear offline which messes up messaging.
+         user_accesstime_log($course->id);
++
++        foreach ($afterlogins as $plugintype => $plugins) {
++            foreach ($plugins as $pluginfunction) {
++                $pluginfunction($courseorid, $autologinguest, $cm, $setwantsurltome, $preventredirect);
++            }
++        }
+         return;
+     }
+ 
+@@ -3176,6 +3184,12 @@ function require_login($courseorid = null, $autologinguest = true, $cm = null, $
+         }
+     }
+ 
++    foreach ($afterlogins as $plugintype => $plugins) {
++        foreach ($plugins as $pluginfunction) {
++            $pluginfunction($courseorid, $autologinguest, $cm, $setwantsurltome, $preventredirect);
++        }
++    }
++
+     // Finally access granted, update lastaccess times.
+     user_accesstime_log($course->id);
+ }
+diff --git a/server/lib/setup.php b/server/lib/setup.php
+index c05e13b03aa..4d89eda0713 100644
+--- a/server/lib/setup.php
++++ b/server/lib/setup.php
+@@ -800,3 +800,17 @@ if (!function_exists('hash_equals')) {
+         return false;
+     }
+ }
++
++
++// Allow plugins to callback as soon possible after setup.php is loaded.
++$pluginswithfunction = get_plugins_with_function('after_config', 'lib.php');
++foreach ($pluginswithfunction as $plugins) {
++    foreach ($plugins as $function) {
++        try {
++            $function();
++        } catch (Throwable $e) {
++            debugging("Exception calling '$function'", DEBUG_DEVELOPER, $e->getTrace());
++        }
++    }
++}
++


### PR DESCRIPTION
Not sure if you care to maintain Totara compatibility.

These were the only three cases of REXEXP: `('|")static('|")` (mform static elements) I could find in the codebase. This should resolve the issue with static mform elements not allowing html in Totara 13+: #343.

I didn't properly look at xss risks but at a quick glance at each of the changed elements:
 1. QR is entirely generated and should not contain end-user editable content.
 2. I'm not entirely sure whats the deal with xss from languages strings e.g. `setupfactor:linklabel`. Even if lang strings don't have some other form of cleaning, I'd imagine that authorisation to edit lang strings should be a `xss_risk` anyways.
 3. The User's username does get inserted into the table the last element displays.


Checking CFG doesn't feel like a really neat way to have compatibility for both if anyone has a better idea let me know.