### PR TITLE
Fix factor ordering not working when factors are enabled in their settings forms

### DIFF
--- a/factor/admin/settings.php
+++ b/factor/admin/settings.php
@@ -25,9 +25,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings->add(new admin_setting_configcheckbox('factor_admin/enabled',
+$enabled = new admin_setting_configcheckbox('factor_admin/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('admin', get_config('factor_admin', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_admin/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/auth/settings.php
+++ b/factor/auth/settings.php
@@ -25,9 +25,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings->add(new admin_setting_configcheckbox('factor_auth/enabled',
+$enabled = new admin_setting_configcheckbox('factor_auth/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('auth', get_config('factor_auth', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_auth/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/capability/settings.php
+++ b/factor/capability/settings.php
@@ -25,9 +25,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings->add(new admin_setting_configcheckbox('factor_capability/enabled',
+$enabled = new admin_setting_configcheckbox('factor_capability/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('capability', get_config('factor_capability', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_capability/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/email/settings.php
+++ b/factor/email/settings.php
@@ -25,9 +25,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings->add(new admin_setting_configcheckbox('factor_email/enabled',
+$enabled = new admin_setting_configcheckbox('factor_email/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('email', get_config('factor_email', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_email/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/grace/settings.php
+++ b/factor/grace/settings.php
@@ -25,9 +25,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings->add(new admin_setting_configcheckbox('factor_grace/enabled',
+$enabled = new admin_setting_configcheckbox('factor_grace/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('grace', get_config('factor_grace', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_grace/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/iprange/settings.php
+++ b/factor/iprange/settings.php
@@ -27,9 +27,13 @@ defined('MOODLE_INTERNAL') || die();
 
 global $OUTPUT;
 
-$settings->add(new admin_setting_configcheckbox('factor_iprange/enabled',
+$enabled = new admin_setting_configcheckbox('factor_iprange/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('iprange', get_config('factor_iprange', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_iprange/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/loginbanner/settings.php
+++ b/factor/loginbanner/settings.php
@@ -25,9 +25,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings->add(new admin_setting_configcheckbox('factor_loginbanner/enabled',
+$enabled = new admin_setting_configcheckbox('factor_loginbanner/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('loginbanner', get_config('factor_loginbanner', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_loginbanner/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/nosetup/settings.php
+++ b/factor/nosetup/settings.php
@@ -25,9 +25,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings->add(new admin_setting_configcheckbox('factor_nosetup/enabled',
+$enabled = new admin_setting_configcheckbox('factor_nosetup/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('nosetup', get_config('factor_nosetup', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_nosetup/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/role/settings.php
+++ b/factor/role/settings.php
@@ -25,9 +25,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings->add(new admin_setting_configcheckbox('factor_role/enabled',
+$enabled = new admin_setting_configcheckbox('factor_role/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('role', get_config('factor_role', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_role/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/secq/settings.php
+++ b/factor/secq/settings.php
@@ -25,9 +25,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings->add(new admin_setting_configcheckbox('factor_secq/enabled',
+$enabled = new admin_setting_configcheckbox('factor_secq/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('secq', get_config('factor_secq', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_secq/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/sms/settings.php
+++ b/factor/sms/settings.php
@@ -26,9 +26,13 @@
 defined('MOODLE_INTERNAL') || die();
 global $CFG, $OUTPUT;
 
-$settings->add(new admin_setting_configcheckbox('factor_sms/enabled',
+$enabled = new admin_setting_configcheckbox('factor_sms/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('sms', get_config('factor_sms', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_sms/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/token/settings.php
+++ b/factor/token/settings.php
@@ -26,9 +26,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings->add(new admin_setting_configcheckbox('factor_token/enabled',
+$enabled = new admin_setting_configcheckbox('factor_token/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('token', get_config('factor_token', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_token/weight',
     new lang_string('settings:weight', 'tool_mfa'),

--- a/factor/totp/settings.php
+++ b/factor/totp/settings.php
@@ -26,9 +26,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings->add(new admin_setting_configcheckbox('factor_totp/enabled',
+$enabled = new admin_setting_configcheckbox('factor_totp/enabled',
     new lang_string('settings:enablefactor', 'tool_mfa'),
-    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0));
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('totp', get_config('factor_totp', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
 
 $settings->add(new admin_setting_configtext('factor_totp/weight',
     new lang_string('settings:weight', 'tool_mfa'),


### PR DESCRIPTION
If you enable a factor by using the checkbox in the factor's settings form, it does not add the factor to the `tool_mfa/factor_order` setting, which then causes the factor table to not display the enabled factor at the top, and it cannot be moved around the table.

Fixes #130 #182 #208 