### PR TITLE
Fix totara support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,12 @@ The other major difference is that we support multiple authentication factor **t
 `master` is considered stable and supports these versions, with the caveat of backporting the API's needed.
 A minimum of PHP7.0 is required to run this plugin.
 
-| Moodle Version    |  Branch      | Patches              |
-|-------------------|--------------|----------------------|
-| Moodle 3.8 -3.9   | master       | None                 |
-| Moodle 3.7        | master       | MDL-66340            |
-| Moodle 3.5-3.6    | master       | MDL-66340, MDL-60470 |
+| Version         |  Branch      | Patches              |
+|-----------------|--------------|----------------------|
+| Moodle 3.8 -3.9 | master       | None                 |
+| Moodle 3.7      | master       | MDL-66340            |
+| Moodle 3.5-3.6  | master       | MDL-66340, MDL-60470 |
+| Totara 12-15    | master       | MDL-66340, MDL-60470 |
 
 ## Installation
 

--- a/renderer.php
+++ b/renderer.php
@@ -519,7 +519,7 @@ class tool_mfa_renderer extends plugin_renderer_base {
 
         $result = parent::mform_element($element, $required, $advanced, $error, $ingroup);
 
-        if (!empty($script)) {
+        if (!empty($script) && $result !== false) {
             $result .= $script;
         }
 


### PR DESCRIPTION
On Totara the core renderer is updated to render mform elements via templates (https://github.com/moodle/moodle/blob/master/lib/outputrenderers.php#L4840) but the templates do not exist.
The formslib has a fallback for this (https://github.com/moodle/moodle/blob/master/lib/formslib.php#L3174) but relies on `mform_element` returning an empty variable.
The mfa renderer will append the securejs script regardless of what the core renderer returns. The result is that the verification_field is not rendered.
This only happens in debugmode because the mfa renderer isn't set in `auth.php` until https://github.com/catalyst/moodle-tool_mfa/blob/master/classes/manager.php#L102 is hit

I've also updated the readme to show support for Totara 12-15. We have it enabled on 12,13,15 sites with no issues.