### PR TITLE
Do not cut chars for factors summary on table

### DIFF
--- a/classes/local/admin_setting_managemfa.php
+++ b/classes/local/admin_setting_managemfa.php
@@ -207,7 +207,6 @@ class admin_setting_managemfa extends \admin_setting {
                 . ' <sup>' . $factor->get_weight() . '</sup>';
             }
 
-            $string = substr($string, 4);
             $table->data[] = new \html_table_row([$string, $combination['totalweight']]);
         }
 


### PR DESCRIPTION
Right now table is showing cuted strings at start. This strings are only used here, then I think cut it is an error.