### PR TITLE
Get config from Moodle to set token cookie

### DIFF
--- a/factor/token/classes/factor.php
+++ b/factor/token/classes/factor.php
@@ -194,7 +194,9 @@ class factor extends object_factor_base {
         $secretmanager->create_secret($expiry, false, $secret);
 
         // All the prep is now done, we can set this cookie.
-        setcookie($cookie, $secret, $expirytime, $CFG->sessioncookiepath, $CFG->sessioncookiedomain, false, true);
+        $cookiesecure = 1 == get_config('core', 'cookiesecure');
+        $cookiehttponly = 1 == get_config('core', 'cookiehttponly');
+        setcookie($cookie, $secret, $expirytime, $CFG->sessioncookiepath, $CFG->sessioncookiedomain, $cookiesecure, $cookiehttponly);
 
         // Finally emit a log event for storing the cookie.
         $state = [


### PR DESCRIPTION
Check and apply the configured values of Moodle for *cookiesecure* and *cookiehttponly* on token cookie

![imagen](https://user-images.githubusercontent.com/66381987/218104861-c85e8e27-e5f2-473f-8f8f-9b36adcb7521.png)

![imagen](https://user-images.githubusercontent.com/66381987/218105097-425564d4-7e5f-4b00-a33b-ca0acc4f7d32.png)
