### PR TITLE
Totara 17.3+ patchless support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ A minimum of PHP7.0 is required to run this plugin.
 | Moodle 3.8 -3.9 | master       | None                 |
 | Moodle 3.7      | master       | MDL-66340            |
 | Moodle 3.5-3.6  | master       | MDL-66340, MDL-60470 |
-| Totara 12-15    | master       | MDL-66340, MDL-60470 |
+| Totara 12-17    | master       | MDL-66340, MDL-60470 |
+| Totara 17.3+    | master       | None                 |
 
 ## Installation
 

--- a/classes/watcher/login_watcher.php
+++ b/classes/watcher/login_watcher.php
@@ -1,0 +1,67 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_mfa\watcher;
+
+defined('MOODLE_INTERNAL') || die();
+
+use core\hook\after_require_login;
+use core\hook\after_config;
+use totara_core\hook\base;
+
+// Hooks are Totara specific.
+if (!class_exists(base::class)) {
+    return;
+}
+
+require_once($CFG->dirroot . '/admin/tool/mfa/lib.php');
+
+/**
+ * Watches Totara hooks to ensure a user is authenticated.
+ *
+ * Forwards on the events until Totara implements:
+ * `TODO - PLATFORM-117 to create a watcher to enable those functions via this hook`
+ *
+ * @package     tool_mfa
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class login_watcher {
+    /**
+     * Forwards calls to tool_mfa_after_require_login.
+     *
+     * @param after_require_login $hook
+     */
+    public static function ensure_authenticated(after_require_login $hook) {
+        tool_mfa_after_require_login(
+            $hook->courseorid,
+            $hook->autologinguest,
+            $hook->cm,
+            $hook->setwantsurltome,
+            $hook->preventredirect
+        );
+    }
+
+    /**
+     * Forwards calls to tool_mfa_after_config.
+     *
+     * @param after_config $hook
+     */
+    public static function check_authenticated(after_config $hook) {
+        tool_mfa_after_config();
+    }
+}

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -1,0 +1,52 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Definition of MFA sub-plugins (factors).
+ *
+ * @package     tool_mfa
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+use core\hook\after_require_login;
+use core\hook\after_config;
+use tool_mfa\watcher\login_watcher;
+use totara_core\hook\base;
+
+// Hooks are Totara specific.
+if (!class_exists(base::class)) {
+    return;
+}
+
+$watchers = [
+    [
+        'hookname' => after_require_login::class,
+        'callback' => [login_watcher::class, 'ensure_authenticated'],
+        'includefile' => null,
+        'priority' => 100,
+    ],
+    [
+        'hookname' => after_config::class,
+        'callback' => [login_watcher::class, 'check_authenticated'],
+        'includefile' => null,
+        'priority' => 100,
+    ],
+];
+


### PR DESCRIPTION
## Changes
This patch attempts to watch the newly introduced Totara hooks:
 - `\core\hook\after_require_login`
 - `\core\hook\after_config`

It will forward any calls to them along to the existing lib.php callbacks (`tool_mfa_after_config` & `tool_mfa_after_require_login`) that check for authentication.

These hooks were introduced as part of TL-35168. If you are not familar with Totara hooks documentation is available here: https://help.totaralearning.com/display/DEV/Hooks+developer+documentation

This will authenticate users on Totara (17.3+) without the need for core patches.

All changes in this patch are gated with a class_exists check for `\totara_core\hook\base` to ensure MOODLE compatibility.

---
## Three things to consider

1.	It seems the plan in the future is for these hooks to automatically search for functions in lib.php as normal to preserve functionality with MOODLE plugins. That future plan will hopefully render this change obsolete and make this plugin work with Totara without any changes.
	
	The source for that plan is a code comment:
	`TODO - PLATFORM-117 to create a watcher to enable those functions via this hook` in one of the 
	newly introduced hooks.

1. I'm sure the `\class_exists()` in hooks.php is not needed but it can't hurt to be explicit.

1.	With this patch lib.php callbacks could potentially be called before the plugin is installed or enabled. This is different to the MOODLE hook style with `get_plugins_with_function` which does something like:
	```php
	if (!isset($installedplugins[$plugin])) {
	    // Plugin code is still present on disk but it is not installed.
	    unset($pluginfunctions[$plugintype][$plugin]);
	    continue;
	}
	```
	
	At the moment the `tool_mfa\manager::require_auth` invoked via the lib.php callbacks handles this in it's call to: `\tool_mfa\manager::is_ready`. However if anything new was introduced directly to lib.php callbacks that requires installed plugin functionality it may create issues.
	
	I think it's safe to ignore for now especially since Totara seemingly plans to make this obsolete in the future.