### PR TITLE
factor_webauthn: Base64 encode AAGUID registration field

### DIFF
--- a/factor/webauthn/classes/factor.php
+++ b/factor/webauthn/classes/factor.php
@@ -306,6 +306,7 @@ class factor extends object_factor_base {
                 $this->webauthn->processCreate($clientdata, $attestationobject, $challenge, $this->userverification === 'required',
                     true, false);
             $registration->credentialId = base64_encode($registration->credentialId);
+            $registration->AAGUID = base64_encode($registration->AAGUID);
             unset($registration->certificate);
 
             $row = new \stdClass();


### PR DESCRIPTION
Some AAGUIDs return as 16 zero bytes, others return a CBOR (binary object). This encodes all aaguids to base64 so they can be properly stored.

Resolves #390 