### PR TITLE
Remove tags from devicename

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -132,5 +132,15 @@ function xmldb_tool_mfa_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2021021900, 'tool', 'mfa');
     }
 
+    if ($oldversion < 2023031601) {
+        // Update the label field for TOTP to strip tags.
+        $records = $DB->get_records_select('tool_mfa', $DB->sql_like('label', '?'), ['%<%'], '', 'id, label');
+        foreach ($records as $record) {
+            $DB->set_field('tool_mfa', 'label', strip_tags($record->label), ['id' => $record->id]);
+        }
+        // Mfa savepoint reached.
+        upgrade_plugin_savepoint(true, 2023031601, 'tool', 'mfa');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -136,7 +136,7 @@ function xmldb_tool_mfa_upgrade($oldversion) {
         // Update the label field for TOTP to strip tags.
         $records = $DB->get_records_select('tool_mfa', $DB->sql_like('label', '?'), ['%<%'], '', 'id, label');
         foreach ($records as $record) {
-            $DB->set_field('tool_mfa', 'label', strip_tags($record->label), ['id' => $record->id]);
+            $DB->set_field('tool_mfa', 'label', htmlspecialchars(strip_tags($record->label)), ['id' => $record->id]);
         }
         // Mfa savepoint reached.
         upgrade_plugin_savepoint(true, 2023031601, 'tool', 'mfa');

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -136,7 +136,7 @@ function xmldb_tool_mfa_upgrade($oldversion) {
         // Update the label field for TOTP to strip tags.
         $records = $DB->get_records_select('tool_mfa', $DB->sql_like('label', '?'), ['%<%'], '', 'id, label');
         foreach ($records as $record) {
-            $DB->set_field('tool_mfa', 'label', htmlspecialchars(strip_tags($record->label)), ['id' => $record->id]);
+            $DB->set_field('tool_mfa', 'label', clean_param($record->label, PARAM_ALPHANUMEXT), ['id' => $record->id]);
         }
         // Mfa savepoint reached.
         upgrade_plugin_savepoint(true, 2023031601, 'tool', 'mfa');

--- a/factor/totp/classes/factor.php
+++ b/factor/totp/classes/factor.php
@@ -347,7 +347,7 @@ class factor extends object_factor_base {
             $row->userid = $USER->id;
             $row->factor = $this->name;
             $row->secret = $data->secret;
-            $row->label = strip_tags($data->devicename);
+            $row->label = htmlspecialchars(strip_tags($data->devicename));
             $row->timecreated = time();
             $row->createdfromip = $USER->lastip;
             $row->timemodified = time();

--- a/factor/totp/classes/factor.php
+++ b/factor/totp/classes/factor.php
@@ -347,7 +347,7 @@ class factor extends object_factor_base {
             $row->userid = $USER->id;
             $row->factor = $this->name;
             $row->secret = $data->secret;
-            $row->label = $data->devicename;
+            $row->label = strip_tags($data->devicename);
             $row->timecreated = time();
             $row->createdfromip = $USER->lastip;
             $row->timemodified = time();

--- a/factor/totp/classes/factor.php
+++ b/factor/totp/classes/factor.php
@@ -147,7 +147,7 @@ class factor extends object_factor_base {
             'autofocus' => 'autofocus',
         ]);
         $mform->addHelpButton('devicename', 'devicename', 'factor_totp');
-        $mform->setType('devicename', PARAM_TEXT);
+        $mform->setType('devicename', PARAM_ALPHANUMEXT);
         $mform->addRule('devicename', get_string('required'), 'required', null, 'client');
 
         // Scan.
@@ -347,7 +347,7 @@ class factor extends object_factor_base {
             $row->userid = $USER->id;
             $row->factor = $this->name;
             $row->secret = $data->secret;
-            $row->label = htmlspecialchars(strip_tags($data->devicename));
+            $row->label = clean_param($data->devicename, PARAM_ALPHANUMEXT);
             $row->timecreated = time();
             $row->createdfromip = $USER->lastip;
             $row->timemodified = time();

--- a/factor/totp/tests/factor_test.php
+++ b/factor/totp/tests/factor_test.php
@@ -145,4 +145,25 @@ class factor_test extends \advanced_testcase {
         $count = $DB->count_records('tool_mfa');
         $this->assertEquals(1, $count);
     }
+
+    /**
+     * Test devicename is saved clean
+     *
+     * @covers ::setup_user_factor
+     */
+    public function test_devicename_cleaned() {
+        global $DB;
+        $this->resetAfterTest();
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+
+        set_config('enabled', 1, 'factor_totp');
+        $totpfactor = \tool_mfa\plugininfo\factor::get_factor('totp');
+        $totpdata = [
+            'secret' => 'fakekey',
+            'devicename' => 'devicename<b>with</b>tag',
+        ];
+        $record = $totpfactor->setup_user_factor((object) $totpdata);
+        $this->assertEquals('devicenamebwithbtag', $record->label);
+    }
 }

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2023031601;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2023031600;      // Same as version.
+$plugin->release   = 2023031601;      // Same as version.
 $plugin->requires  = 2017051500.00;   // Support back to 3.3 - Totara 12. Patches required.
 $plugin->component = 'tool_mfa';
 $plugin->maturity  = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023031600;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2023031601;      // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 2023031600;      // Same as version.
 $plugin->requires  = 2017051500.00;   // Support back to 3.3 - Totara 12. Patches required.
 $plugin->component = 'tool_mfa';


### PR DESCRIPTION
Currently, we can add tags in the device name for TOTP.
This patch prevents adding the tags for device name.