### PR TITLE
Increase TOTP key length to 128

### DIFF
--- a/factor/totp/classes/factor.php
+++ b/factor/totp/classes/factor.php
@@ -314,13 +314,14 @@ class factor extends object_factor_base {
     }
 
     /**
-     * Generates cryptographically secure pseudo-random 16-digit secret code.
+     * Generates cryptographically secure pseudo-random 32-digit secret code
+     * i.e. 128 bit key length as requested by RFC 4226, section 4, requirement 6
      *
      * @return string
      */
     public function generate_secret_code() {
         $totp = TOTP::create();
-        return substr($totp->getSecret(), 0, 16);
+        return substr($totp->getSecret(), 0, 32);
     }
 
     /**


### PR DESCRIPTION
The secret key length of the TOTP factor should be 128 bits as requested by RFC 4226, section 4, requirement 6. As at least one TOTP app, FreeOTP, shows nasty warnings about a weak key when using only 80 bit key length. This commit increases the key length to 128 bit without breaking the compatibility to already existing 80 bit keys in the database for users that have setup TOTP before this change. This solves issue #383