### PR TITLE
Fix loading for factor settings.php to load externalpages

### DIFF
--- a/classes/plugininfo/factor.php
+++ b/classes/plugininfo/factor.php
@@ -59,6 +59,7 @@ class factor extends \core\plugininfo\base {
         return self::sort_factors_by_order($return);
     }
 
+
     /**
      * Sorts factors by configured order.
      *
@@ -260,9 +261,7 @@ class factor extends \core\plugininfo\base {
 
         $settings = new \admin_settingpage($section, $this->displayname, 'moodle/site:config', $this->is_enabled() === false);
 
-        if ($adminroot->fulltree) {
-            include($this->full_path('settings.php'));
-        }
+        include($this->full_path('settings.php'));
 
         $adminroot->add($parentnodename, $settings);
     }


### PR DESCRIPTION
This allows externalpages defined in factor subplugins to be loaded during the admin tree view from admin/search.php