### PR TITLE
Closes #450. Fixed cohort factor list.

### DIFF
--- a/factor/cohort/settings.php
+++ b/factor/cohort/settings.php
@@ -38,10 +38,11 @@ $settings->add(new admin_setting_configtext('factor_cohort/weight',
     new lang_string('settings:weight', 'tool_mfa'),
     new lang_string('settings:weight_help', 'tool_mfa'), 100, PARAM_INT));
 
-$cohorts = cohort_get_all_cohorts();
+global $DB;
+$cohorts = $DB->get_records('cohort', null, 'name asc', 'id,name');
 $choices = [];
 
-foreach ($cohorts['cohorts'] as $cohort) {
+foreach ($cohorts as $cohort) {
     $choices[$cohort->id] = $cohort->name;
 }
 

--- a/factor/cohort/settings.php
+++ b/factor/cohort/settings.php
@@ -38,7 +38,6 @@ $settings->add(new admin_setting_configtext('factor_cohort/weight',
     new lang_string('settings:weight', 'tool_mfa'),
     new lang_string('settings:weight_help', 'tool_mfa'), 100, PARAM_INT));
 
-global $DB;
 $cohorts = $DB->get_records('cohort', null, 'name asc', 'id,name');
 $choices = [];
 


### PR DESCRIPTION
Instead of using `cohort_get_all_cohorts()` method, which returns only 25 cohorts, this modification fetches all the cohorts straight from the database without limitations.