### PR TITLE
[T19] Fix t19 tests

### DIFF
--- a/factor/email/tests/factor_test.php
+++ b/factor/email/tests/factor_test.php
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace factor_email\tests;
-
 /**
  * Tests for TOTP factor.
  *
@@ -25,7 +23,7 @@ namespace factor_email\tests;
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class factor_test extends \core_phpunit\testcase {
+class email_factor_test extends \core_phpunit\testcase {
 
     /**
      * Provides to test_generate_email_ip_address_location test.

--- a/factor/email/tests/factor_test.php
+++ b/factor/email/tests/factor_test.php
@@ -25,7 +25,7 @@ namespace factor_email\tests;
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class factor_test extends \advanced_testcase {
+class factor_test extends \core_phpunit\testcase {
 
     /**
      * Provides to test_generate_email_ip_address_location test.

--- a/factor/grace/tests/factor_test.php
+++ b/factor/grace/tests/factor_test.php
@@ -24,7 +24,7 @@ namespace factor_grace\tests;
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class factor_test extends \advanced_testcase {
+class factor_test extends \core_phpunit\testcase {
 
     public function test_affecting_factors() {
         $this->resetAfterTest(true);

--- a/factor/grace/tests/factor_test.php
+++ b/factor/grace/tests/factor_test.php
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace factor_grace\tests;
-
 /**
  * Tests for grace factor.
  *
@@ -24,7 +22,7 @@ namespace factor_grace\tests;
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class factor_test extends \core_phpunit\testcase {
+class grace_factor_test extends \core_phpunit\testcase {
 
     public function test_affecting_factors() {
         $this->resetAfterTest(true);

--- a/factor/token/tests/factor_test.php
+++ b/factor/token/tests/factor_test.php
@@ -25,7 +25,7 @@ namespace factor_token\tests;
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class factor_test extends \advanced_testcase {
+class factor_test extends \core_phpunit\testcase {
 
     public function setUp(): void {
         $this->resetAfterTest();

--- a/factor/token/tests/factor_test.php
+++ b/factor/token/tests/factor_test.php
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace factor_token\tests;
-
 /**
  * Tests for MFA manager class.
  *
@@ -25,7 +23,7 @@ namespace factor_token\tests;
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class factor_test extends \core_phpunit\testcase {
+class token_factor_test extends \core_phpunit\testcase {
 
     public function setUp(): void {
         $this->resetAfterTest();

--- a/factor/totp/tests/factor_test.php
+++ b/factor/totp/tests/factor_test.php
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace factor_totp\tests;
-
 defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__.'/../extlib/OTPHP/OTPInterface.php');
@@ -37,7 +35,7 @@ require_once(__DIR__.'/../extlib/Assert/InvalidArgumentException.php');
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class factor_test extends \core_phpunit\testcase {
+class totp_factor_test extends \core_phpunit\testcase {
 
     /**
      * Test code validation of the TOTP factor

--- a/factor/totp/tests/factor_test.php
+++ b/factor/totp/tests/factor_test.php
@@ -37,7 +37,7 @@ require_once(__DIR__.'/../extlib/Assert/InvalidArgumentException.php');
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class factor_test extends \advanced_testcase {
+class factor_test extends \core_phpunit\testcase {
 
     /**
      * Test code validation of the TOTP factor

--- a/tests/admin_setting_managemfa_test.php
+++ b/tests/admin_setting_managemfa_test.php
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace tool_mfa\tests;
-
 defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . '/tool_mfa_testcase.php');

--- a/tests/manager_test.php
+++ b/tests/manager_test.php
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace tool_mfa\tests;
-
 defined('MOODLE_INTERNAL') || die();
 require_once(__DIR__ . '/tool_mfa_testcase.php');
 

--- a/tests/object_factor_base_test.php
+++ b/tests/object_factor_base_test.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-namespace tool_mfa\tests;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/plugininfo_factor_test.php
+++ b/tests/plugininfo_factor_test.php
@@ -22,7 +22,7 @@
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class plugininfo_factor_test extends advanced_testcase {
+class plugininfo_factor_test extends \core_phpunit\testcase {
 
     public function test_get_next_user_factor() {
 

--- a/tests/secret_manager_test.php
+++ b/tests/secret_manager_test.php
@@ -24,7 +24,7 @@ namespace tool_mfa\tests;
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class secret_manager_test extends \advanced_testcase {
+class secret_manager_test extends \core_phpunit\testcase {
 
     public function test_create_secret() {
         global $DB;

--- a/tests/secret_manager_test.php
+++ b/tests/secret_manager_test.php
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace tool_mfa\tests;
-
 /**
  * Tests for MFA secret manager class.
  *

--- a/tests/tool_mfa_testcase.php
+++ b/tests/tool_mfa_testcase.php
@@ -31,7 +31,7 @@ require_once(__DIR__ . '/../lib.php');
  * @copyright   Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-abstract class tool_mfa_testcase extends \advanced_testcase {
+abstract class tool_mfa_testcase extends \core_phpunit\testcase {
 
     /**
      * Sets the state of the factor, in particular the weight and whether it is enabled

--- a/tests/tool_mfa_testcase.php
+++ b/tests/tool_mfa_testcase.php
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace tool_mfa\tests;
-
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;


### PR DESCRIPTION
Adds fixes so unit tests can run with Tōtara 19.

I created this MR against the branch currently used for Tōtara 18 sites but it'll likely need a new TOTARA_19 branch.
