### PR TITLE
factor_token: explicitly declare class property

### DIFF
--- a/factor/token/tests/factor_test.php
+++ b/factor/token/tests/factor_test.php
@@ -25,6 +25,9 @@
  */
 class token_factor_test extends \core_phpunit\testcase {
 
+    /** @var string */
+    private $factor;
+
     public function setUp(): void {
         $this->resetAfterTest();
         $this->factor = new \factor_token\factor('token');


### PR DESCRIPTION
Resolves error 'Creation of dynamic property token_factor_test:: is deprecated'