### PR TITLE
PHPUnit data providers names must not start with test

### DIFF
--- a/tests/admin_setting_managemfa_test.php
+++ b/tests/admin_setting_managemfa_test.php
@@ -37,7 +37,7 @@ class admin_setting_managemfa_test extends tool_mfa_testcase {
         $this->assertEquals(0, count($combinations));
     }
 
-    public static function test_get_factor_combinations_provider() {
+    public static function get_factor_combinations_provider() {
         $provider = [];
 
         $factors = [];
@@ -122,7 +122,7 @@ class admin_setting_managemfa_test extends tool_mfa_testcase {
     /**
      * Tests getting the factor combinations
      *
-     * @dataProvider test_get_factor_combinations_provider
+     * @dataProvider get_factor_combinations_provider
      * @param array $factorset configured factors
      * @param int $combinationscount expected count of available combinations
      */


### PR DESCRIPTION
Addresses this warning:

There was 1 PHPUnit test runner warning:

    Method admin_setting_managemfa_test::test_get_factor_combinations_provider() used by test method admin_setting_managemfa_test::test_get_factor_combinations_with_data_provider() is also a test method

Running PHPUnit 10.5.63

Documentation: https://docs.phpunit.de/en/10.5/writing-tests-for-phpunit.html#data-providers
A data provider method must be public and static and its name must not start with test