### PR TITLE
fix naming of data provider

### DIFF
--- a/tests/admin_setting_managemfa_test.php
+++ b/tests/admin_setting_managemfa_test.php
@@ -37,7 +37,7 @@ class admin_setting_managemfa_test extends tool_mfa_testcase {
         $this->assertEquals(0, count($combinations));
     }
 
-    public static function test_get_factor_combinations_provider() {
+    public static function get_factor_combinations_provider() {
         $provider = [];
 
         $factors = [];
@@ -122,7 +122,7 @@ class admin_setting_managemfa_test extends tool_mfa_testcase {
     /**
      * Tests getting the factor combinations
      *
-     * @dataProvider test_get_factor_combinations_provider
+     * @dataProvider get_factor_combinations_provider
      * @param array $factorset configured factors
      * @param int $combinationscount expected count of available combinations
      */


### PR DESCRIPTION
Fixes this test warning

```
There was 1 PHPUnit test runner warning:

1) Method admin_setting_managemfa_test::test_get_factor_combinations_provider() used by test method admin_setting_managemfa_test::test_get_factor_combinations_with_data() is also a test method
```

this was happening because the data provider was prefixed with `test_`, which made phpunit think it was a test.